### PR TITLE
Increase logo size from 2rem to 3rem

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/ideav/work-weave-logic/issues/5
-Your prepared branch: issue-5-589228c443f0
-Your prepared working directory: /tmp/gh-issue-solver-1765376718174
-Your forked repository: unidel2035/ideav-work-weave-logic
-Original repository (upstream): ideav/work-weave-logic
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/ideav/work-weave-logic/issues/5
+Your prepared branch: issue-5-589228c443f0
+Your prepared working directory: /tmp/gh-issue-solver-1765376718174
+Your forked repository: unidel2035/ideav-work-weave-logic
+Original repository (upstream): ideav/work-weave-logic
+
+Proceed.

--- a/src/components/landing/Header.tsx
+++ b/src/components/landing/Header.tsx
@@ -36,7 +36,7 @@ const Header = () => {
             <img
               src="/logo-integram.svg"
               alt="Интеграм"
-              className="h-8"
+              className="h-12"
             />
           </a>
 


### PR DESCRIPTION
## 📋 Summary

This PR increases the logo size in the header from 2rem (32px) to 3rem (48px) as requested in issue #5.

## 🔧 Changes Made

- Updated `src/components/landing/Header.tsx` line 39
- Changed logo `className` from `h-8` (2rem/32px) to `h-12` (3rem/48px)

## 📝 Implementation Details

In Tailwind CSS:
- `h-8` = 2rem = 32px
- `h-12` = 3rem = 48px

The change makes the Integram logo more prominent in the header while maintaining the existing responsive design and layout.

## ✅ Testing

- Verified the change is a simple CSS class update
- No breaking changes introduced
- Maintains existing responsive behavior

## 🔗 Related

Fixes #5

---
*This PR was created automatically by the AI issue solver*